### PR TITLE
AutoCompressionでのクラッシュ問題修正

### DIFF
--- a/src/main/java/otamusan/common/automaticcompression/CompressionInChest.java
+++ b/src/main/java/otamusan/common/automaticcompression/CompressionInChest.java
@@ -1,14 +1,20 @@
 package otamusan.common.automaticcompression;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.collect.Maps;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.init.Blocks;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.WorldTickEvent;
@@ -16,30 +22,39 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.WorldTickEvent;
 public class CompressionInChest {
 	@SubscribeEvent
 	public void onUpdate(WorldTickEvent event) {
-		List<Entity> entitylist = event.world.getLoadedEntityList();
-		for (Entity entity : entitylist) {
-			if (!(entity instanceof EntityItemFrame))
-				continue;
-			EntityItemFrame frame = (EntityItemFrame) entity;
-			if (!(frame.getDisplayedItem().getItem() instanceof ItemBlock))
-				continue;
+		Map<BlockPos, Block> candidates = Maps.newHashMap();
 
-			BlockPos pos = entity.getPosition().offset(frame.getAdjustedHorizontalFacing(), -1).down();
-			if (!(event.world.getTileEntity(pos) instanceof IInventory))
-				continue;
-			IInventory inventory = (IInventory) event.world.getTileEntity(pos);
-
-			if (((ItemBlock) frame.getDisplayedItem().getItem()).getBlock() == Blocks.PISTON) {
-				AutoCompression.autocompression(inventory);
-			} else if (((ItemBlock) frame.getDisplayedItem().getItem()).getBlock() == Blocks.STICKY_PISTON) {
-				List<ItemStack> remains = AutoCompression.fastautocompression(inventory);
-
-				for (ItemStack itemStack : remains) {
-					Block.spawnAsEntity(event.world, pos.add(0.5, 0.5, 0.5), itemStack);
-
+		for (Entity entity : event.world.getLoadedEntityList()) {
+			if (entity instanceof EntityItemFrame) {
+				EntityItemFrame frame = (EntityItemFrame) entity;
+				Item displayedItem = frame.getDisplayedItem().getItem();
+				if (displayedItem instanceof ItemBlock) {
+					Block displayedBlock = ((ItemBlock) displayedItem).getBlock();
+					if (displayedBlock==Blocks.PISTON||displayedBlock==Blocks.STICKY_PISTON) {
+						BlockPos pos = entity.getPosition().offset(frame.getAdjustedHorizontalFacing(), -1).down();
+						candidates.put(pos, displayedBlock);
+					}
 				}
 			}
+		}
 
+		for (Entry<BlockPos, Block> entry : candidates.entrySet()) {
+			BlockPos pos = entry.getKey();
+			Block type = entry.getValue();
+
+			TileEntity tile = event.world.getTileEntity(pos);
+			if (tile instanceof IInventory) {
+				IInventory inventory = (IInventory) tile;
+				if (type==Blocks.PISTON) {
+					AutoCompression.autocompression(inventory);
+				} else if (type==Blocks.STICKY_PISTON) {
+					List<ItemStack> remains = AutoCompression.fastautocompression(inventory);
+
+					for (ItemStack itemStack : remains) {
+						Block.spawnAsEntity(event.world, pos.add(0.5, 0.5, 0.5), itemStack);
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## ワールド読み込み時にAutoCompression関連でクラッシュするバグを修正
`World#getTileEntity(BlockPos)`を呼ぶと`World#getLoadedEntityList()`で得られるリストが変更されてしまうのが原因
```
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.next(ArrayList.java:859)
	at otamusan.common.automaticcompression.CompressionInChest.onUpdate(CompressionInChest.java:20)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_13_CompressionInChest_onUpdate_WorldTickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:182)
	at net.minecraftforge.fml.common.FMLCommonHandler.onPreWorldTick(FMLCommonHandler.java:287)
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:827)
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:743)
	at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:192)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:592)
	at java.lang.Thread.run(Thread.java:748)
```